### PR TITLE
load json file with utf-8 encoding

### DIFF
--- a/scripts/StyleSelectorXL.py
+++ b/scripts/StyleSelectorXL.py
@@ -11,7 +11,7 @@ stylespath = ""
 
 def get_json_content(file_path):
     try:
-        with open(file_path, 'r') as file:
+        with open(file_path, 'rt', encoding="utf-8") as file:
             json_data = json.load(file)
             return json_data
     except Exception as e:


### PR DESCRIPTION
This addition loads the "sdxl_styles.json" file with UTF-8 encoding, see "Pokémon" style.