### PR TITLE
Added full SDXL style list from stable-diffusion-art.com

### DIFF
--- a/sdxl_styles.json
+++ b/sdxl_styles.json
@@ -5,382 +5,517 @@
     "negative_prompt": ""
   },
   {
-    "name": "3D Model",
+    "name": "AI 3D Model",
     "prompt": "professional 3d model {prompt} . octane render, highly detailed, volumetric, dramatic lighting",
     "negative_prompt": "ugly, deformed, noisy, low poly, blurry, painting"
   },
   {
-    "name": "Analog Film",
+    "name": "AI Analog Film",
     "prompt": "analog film photo {prompt} . faded film, desaturated, 35mm photo, grainy, vignette, vintage, Kodachrome, Lomography, stained, highly detailed, found footage",
     "negative_prompt": "painting, drawing, illustration, glitch, deformed, mutated, cross-eyed, ugly, disfigured"
   },
   {
-    "name": "Anime",
+    "name": "AI Anime",
     "prompt": "anime artwork {prompt} . anime style, key visual, vibrant, studio anime,  highly detailed",
     "negative_prompt": "photo, deformed, black and white, realism, disfigured, low contrast"
   },
   {
-    "name": "Cinematic",
+    "name": "AI Cinematic",
     "prompt": "cinematic film still {prompt} . shallow depth of field, vignette, highly detailed, high budget, bokeh, cinemascope, moody, epic, gorgeous, film grain, grainy",
     "negative_prompt": "anime, cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed, mutated, ugly, disfigured"
   },
   {
-    "name": "Comic Book",
+    "name": "AI Comic Book",
     "prompt": "comic {prompt} . graphic illustration, comic art, graphic novel art, vibrant, highly detailed",
     "negative_prompt": "photograph, deformed, glitch, noisy, realistic, stock photo"
   },
   {
-    "name": "Craft Clay",
+    "name": "AI Craft Clay",
     "prompt": "play-doh style {prompt} . sculpture, clay art, centered composition, Claymation",
     "negative_prompt": "sloppy, messy, grainy, highly detailed, ultra textured, photo"
   },
   {
-    "name": "Digital Art",
+    "name": "AI Digital Art",
     "prompt": "concept art {prompt} . digital artwork, illustrative, painterly, matte painting, highly detailed",
     "negative_prompt": "photo, photorealistic, realism, ugly"
   },
   {
-    "name": "Enhance",
+    "name": "AI Enhance",
     "prompt": "breathtaking {prompt} . award-winning, professional, highly detailed",
     "negative_prompt": "ugly, deformed, noisy, blurry, distorted, grainy"
   },
   {
-    "name": "Fantasy Art",
+    "name": "AI Fantasy Art",
     "prompt": "ethereal fantasy concept art of  {prompt} . magnificent, celestial, ethereal, painterly, epic, majestic, magical, fantasy art, cover art, dreamy",
     "negative_prompt": "photographic, realistic, realism, 35mm film, dslr, cropped, frame, text, deformed, glitch, noise, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, sloppy, duplicate, mutated, black and white"
   },
   {
-    "name": "Isometric Style",
+    "name": "AI Isometric Style",
     "prompt": "isometric style {prompt} . vibrant, beautiful, crisp, detailed, ultra detailed, intricate",
     "negative_prompt": "deformed, mutated, ugly, disfigured, blur, blurry, noise, noisy, realistic, photographic"
   },
   {
-    "name": "Line Art",
+    "name": "AI Line Art",
     "prompt": "line art drawing {prompt} . professional, sleek, modern, minimalist, graphic, line art, vector graphics",
     "negative_prompt": "anime, photorealistic, 35mm film, deformed, glitch, blurry, noisy, off-center, deformed, cross-eyed, closed eyes, bad anatomy, ugly, disfigured, mutated, realism, realistic, impressionism, expressionism, oil, acrylic"
   },
   {
-    "name": "Lowpoly",
+    "name": "AI Lowpoly",
     "prompt": "low-poly style {prompt} . low-poly game art, polygon mesh, jagged, blocky, wireframe edges, centered composition",
     "negative_prompt": "noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo"
   },
   {
-    "name": "Neon Punk",
+    "name": "AI Neon Punk",
     "prompt": "neonpunk style {prompt} . cyberpunk, vaporwave, neon, vibes, vibrant, stunningly beautiful, crisp, detailed, sleek, ultramodern, magenta highlights, dark purple shadows, high contrast, cinematic, ultra detailed, intricate, professional",
     "negative_prompt": "painting, drawing, illustration, glitch, deformed, mutated, cross-eyed, ugly, disfigured"
   },
   {
-    "name": "Origami",
+    "name": "AI Origami",
     "prompt": "origami style {prompt} . paper art, pleated paper, folded, origami art, pleats, cut and fold, centered composition",
     "negative_prompt": "noisy, sloppy, messy, grainy, highly detailed, ultra textured, photo"
   },
   {
-    "name": "Photographic",
+    "name": "AI Photographic",
     "prompt": "cinematic photo {prompt} . 35mm photograph, film, bokeh, professional, 4k, highly detailed",
     "negative_prompt": "drawing, painting, crayon, sketch, graphite, impressionist, noisy, blurry, soft, deformed, ugly"
   },
   {
-    "name": "Pixel Art",
+    "name": "AI Pixel Art",
     "prompt": "pixel-art {prompt} . low-res, blocky, pixel art style, 8-bit graphics",
     "negative_prompt": "sloppy, messy, blurry, noisy, highly detailed, ultra textured, photo, realistic"
   },
   {
-    "name": "Texture",
+    "name": "AI Texture",
     "prompt": "texture {prompt} top down close-up",
     "negative_prompt": "ugly, deformed, noisy, blurry"
   },
   {
-    "name": "Advertising",
+    "name": "Ads Advertising",
     "prompt": "Advertising poster style {prompt} . Professional, modern, product-focused, commercial, eye-catching, highly detailed",
     "negative_prompt": "noisy, blurry, amateurish, sloppy, unattractive"
   },
   {
-    "name": "Food Photography",
-    "prompt": "Food photography style {prompt} . Appetizing, professional, culinary, high-resolution, commercial, highly detailed",
+    "name": "Ads Automotive",
+    "prompt": "automotive advertisement style {prompt} . sleek, dynamic, professional, commercial, vehicle-focused, high-resolution, highly detailed",
+    "negative_prompt": "noisy, blurry, unattractive, sloppy, unprofessional"
+  },
+  {
+    "name": "Ads Corporate",
+    "prompt": "corporate branding style {prompt} . professional, clean, modern, sleek, minimalist, business-oriented, highly detailed",
+    "negative_prompt": "noisy, blurry, grungy, sloppy, cluttered, disorganized"
+  },
+  {
+    "name": "Ads Fashion Editorial",
+    "prompt": "fashion editorial style {prompt} . high fashion, trendy, stylish, editorial, magazine style, professional, highly detailed",
+    "negative_prompt": "outdated, blurry, noisy, unattractive, sloppy"
+  },
+  {
+    "name": "Ads Food Photography",
+    "prompt": "food photography style {prompt} . appetizing, professional, culinary, high-resolution, commercial, highly detailed",
     "negative_prompt": "unappetizing, sloppy, unprofessional, noisy, blurry"
   },
   {
-    "name": "Real Estate",
-    "prompt": "Real estate photography style {prompt} . Professional, inviting, well-lit, high-resolution, property-focused, commercial, highly detailed",
+    "name": "Ads Gourmet Food Photography",
+    "prompt": "gourmet food photo of {prompt} . soft natural lighting, macro details, vibrant colors, fresh ingredients, glistening textures, bokeh background, styled plating, wooden tabletop, garnished, tantalizing, editorial quality",
+    "negative_prompt": "cartoon, anime, sketch, grayscale, dull, overexposed, cluttered, messy plate, deformed"
+  },
+  {
+    "name": "Ads Luxury",
+    "prompt": "luxury product style {prompt} . elegant, sophisticated, high-end, luxurious, professional, highly detailed",
+    "negative_prompt": "cheap, noisy, blurry, unattractive, amateurish"
+  },
+  {
+    "name": "Ads Real Estate",
+    "prompt": "real estate photography style {prompt} . professional, inviting, well-lit, high-resolution, property-focused, commercial, highly detailed",
     "negative_prompt": "dark, blurry, unappealing, noisy, unprofessional"
   },
   {
-    "name": "Abstract",
+    "name": "Ads Retail",
+    "prompt": "retail packaging style {prompt} . vibrant, enticing, commercial, product-focused, eye-catching, professional, highly detailed",
+    "negative_prompt": "noisy, blurry, amateurish, sloppy, unattractive"
+  },
+  {
+    "name": "Artstyle Abstract",
     "prompt": "Abstract style {prompt} . Non-representational, colors and shapes, expression of feelings, imaginative, highly detailed",
     "negative_prompt": "realistic, photographic, figurative, concrete"
   },
   {
-    "name": "Cubist",
+    "name": "Artstyle Art Deco",
+    "prompt": "art deco style {prompt} . geometric shapes, bold colors, luxurious, elegant, decorative, symmetrical, ornate, detailed",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, modernist, minimalist"
+  },
+  {
+    "name": "Artstyle Nouveau",
+    "prompt": "art nouveau style {prompt} . elegant, decorative, curvilinear forms, nature-inspired, ornate, detailed",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, modernist, minimalist"
+  },
+  {
+    "name": "Artstyle Cubist",
     "prompt": "Cubist artwork {prompt} . Geometric shapes, abstract, innovative, revolutionary",
     "negative_prompt": "anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy"
   },
   {
-    "name": "Graffiti",
+    "name": "Artstyle Graffiti",
     "prompt": "Graffiti style {prompt} . Street art, vibrant, urban, detailed, tag, mural",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic"
   },
   {
-    "name": "Hyperrealism",
+    "name": "Artstyle Hyperrealism",
     "prompt": "Hyperrealistic art {prompt} . Extremely high-resolution details, photographic, realism pushed to extreme, fine texture, incredibly lifelike",
     "negative_prompt": "simplified, abstract, unrealistic, impressionistic, low resolution"
   },
   {
-    "name": "Impressionist",
+    "name": "Artstyle Impressionist",
     "prompt": "Impressionist painting {prompt} . Loose brushwork, vibrant color, light and shadow play, captures feeling over form",
     "negative_prompt": "anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy"
   },
   {
-    "name": "Pointillism",
+    "name": "Artstyle Pointillism",
     "prompt": "Pointillism style {prompt} . Composed entirely of small, distinct dots of color, vibrant, highly detailed",
     "negative_prompt": "line drawing, smooth shading, large color fields, simplistic"
   },
   {
-    "name": "Pop Art",
+    "name": "Artstyle Pop Art",
     "prompt": "Pop Art style {prompt} . Bright colors, bold outlines, popular culture themes, ironic or kitsch",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, minimalist"
   },
   {
-    "name": "Psychedelic",
+    "name": "Artstyle Psychedelic",
     "prompt": "Psychedelic style {prompt} . Vibrant colors, swirling patterns, abstract forms, surreal, trippy",
     "negative_prompt": "monochrome, black and white, low contrast, realistic, photorealistic, plain, simple"
   },
   {
-    "name": "Renaissance",
+    "name": "Artstyle Renaissance",
     "prompt": "Renaissance style {prompt} . Realistic, perspective, light and shadow, religious or mythological themes, highly detailed",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, modernist, minimalist, abstract"
   },
   {
-    "name": "Steampunk",
+    "name": "Artstyle Steampunk",
     "prompt": "Steampunk style {prompt} . Antique, mechanical, brass and copper tones, gears, intricate, detailed",
     "negative_prompt": "deformed, glitch, noisy, low contrast, anime, photorealistic"
   },
   {
-    "name": "Surrealist",
+    "name": "Artstyle Surrealist",
     "prompt": "Surrealist art {prompt} . Dreamlike, mysterious, provocative, symbolic, intricate, detailed",
     "negative_prompt": "anime, photorealistic, realistic, deformed, glitch, noisy, low contrast"
   },
   {
-    "name": "Typography",
+    "name": "Artstyle Typography",
     "prompt": "Typographic art {prompt} . Stylized, intricate, detailed, artistic, text-based",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic"
   },
   {
-    "name": "Watercolor",
+    "name": "Artstyle Watercolor",
     "prompt": "Watercolor painting {prompt} . Vibrant, beautiful, painterly, detailed, textural, artistic",
     "negative_prompt": "anime, photorealistic, 35mm film, deformed, glitch, low contrast, noisy"
   },
   {
-    "name": "Fighting Game",
+    "name": "Futuristic Biomechanical",
+    "prompt": "biomechanical style {prompt} . blend of organic and mechanical elements, futuristic, cybernetic, detailed, intricate",
+    "negative_prompt": "natural, rustic, primitive, organic, simplistic"
+  },
+  {
+    "name": "Futuristic Biomechanical Cyberpunk",
+    "prompt": "biomechanical cyberpunk {prompt} . cybernetics, human-machine fusion, dystopian, organic meets artificial, dark, intricate, highly detailed",
+    "negative_prompt": "natural, colorful, deformed, sketch, low contrast, watercolor"
+  },
+  {
+    "name": "Futuristic Cybernetic",
+    "prompt": "cybernetic style {prompt} . futuristic, technological, cybernetic enhancements, robotics, artificial intelligence themes",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, historical, medieval"
+  },
+  {
+    "name": "Futuristic Cybernetic Robot",
+    "prompt": "cybernetic robot {prompt} . android, AI, machine, metal, wires, tech, futuristic, highly detailed",
+    "negative_prompt": "organic, natural, human, sketch, watercolor, low contrast"
+  },
+  {
+    "name": "Futuristic Cyberpunk Cityscape",
+    "prompt": "cyberpunk cityscape {prompt} . neon lights, dark alleys, skyscrapers, futuristic, vibrant colors, high contrast, highly detailed",
+    "negative_prompt": "natural, rural, deformed, low contrast, black and white, sketch, watercolor"
+  },
+  {
+    "name": "Futuristic Futuristic",
+    "prompt": "futuristic style {prompt} . sleek, modern, ultramodern, high tech, detailed",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, vintage, antique"
+  },
+  {
+    "name": "Futuristic Retro Cyberpunk",
+    "prompt": "retro cyberpunk {prompt} . 80’s inspired, synthwave, neon, vibrant, detailed, retro futurism",
+    "negative_prompt": "modern, desaturated, black and white, realism, low contrast"
+  },
+  {
+    "name": "Futuristic Retro Futurism",
+    "prompt": "retro-futuristic {prompt} . vintage sci-fi, 50s and 60s style, atomic age, vibrant, highly detailed",
+    "negative_prompt": "contemporary, realistic, rustic, primitive"
+  },
+  {
+    "name": "Futuristic Sci Fi",
+    "prompt": "sci-fi style {prompt} . futuristic, technological, alien worlds, space themes, advanced civilizations",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, historical, medieval"
+  },
+  {
+    "name": "Futuristic Vaporwave",
+    "prompt": "vaporwave style {prompt} . retro aesthetic, cyberpunk, vibrant, neon colors, vintage 80s and 90s style, highly detailed",
+    "negative_prompt": "monochrome, muted colors, realism, rustic, minimalist, dark"
+  },
+  {
+    "name": "Game Bubble Bobble",
+    "prompt": "Bubble Bobble style {prompt} . 8-bit, cute, pixelated, fantasy, vibrant, reminiscent of Bubble Bobble game",
+    "negative_prompt": "realistic, modern, photorealistic, violent, horror"
+  },
+  {
+    "name": "Game Cyberpunk Game",
+    "prompt": "cyberpunk game style {prompt} . neon, dystopian, futuristic, digital, vibrant, detailed, high contrast, reminiscent of cyberpunk genre video games",
+    "negative_prompt": "historical, natural, rustic, low detailed"
+  },
+  {
+    "name": "Game Fighting Game",
     "prompt": "Fighting game style {prompt} . Dynamic, vibrant, action-packed, detailed character design, reminiscent of fighting video games",
     "negative_prompt": "peaceful, calm, minimalist, photorealistic"
   },
   {
-    "name": "GTA",
+    "name": "Game GTA",
     "prompt": "GTA-style artwork {prompt} . Satirical, exaggerated, pop art style, vibrant colors, iconic characters, action-packed",
     "negative_prompt": "realistic, black and white, low contrast, impressionist, cubist, noisy, blurry, deformed"
   },
   {
-    "name": "Super Mario",
+    "name": "Game Super Mario",
     "prompt": "Super Mario style {prompt} . Vibrant, cute, cartoony, fantasy, playful, reminiscent of Super Mario series",
     "negative_prompt": "realistic, modern, horror, dystopian, violent"
   },
   {
-    "name": "Minecraft",
+    "name": "Game Minecraft",
     "prompt": "Minecraft style {prompt} . Blocky, pixelated, vibrant colors, recognizable characters and objects, game assets",
     "negative_prompt": "smooth, realistic, detailed, photorealistic, noise, blurry, deformed"
   },
   {
-    "name": "Pokémon",
+    "name": "Game Pokémon",
     "prompt": "Pokémon style {prompt} . Vibrant, cute, anime, fantasy, reminiscent of Pokémon series",
     "negative_prompt": "realistic, modern, horror, dystopian, violent"
   },
   {
-    "name": "Retro Arcade",
+    "name": "Game Retro Arcade",
     "prompt": "Retro arcade style {prompt} . 8-bit, pixelated, vibrant, classic video game, old school gaming, reminiscent of 80s and 90s arcade games",
     "negative_prompt": "modern, ultra-high resolution, photorealistic, 3D"
   },
   {
-    "name": "Retro Game",
+    "name": "Game Retro Game",
     "prompt": "Retro game art {prompt} . 16-bit, vibrant colors, pixelated, nostalgic, charming, fun",
     "negative_prompt": "realistic, photorealistic, 35mm film, deformed, glitch, low contrast, noisy"
   },
   {
-    "name": "RPG Fantasy Game",
+    "name": "Game RPG Fantasy Game",
     "prompt": "Role-playing game (RPG) style fantasy {prompt} . Detailed, vibrant, immersive, reminiscent of high fantasy RPG games",
     "negative_prompt": "sci-fi, modern, urban, futuristic, low detailed"
   },
   {
-    "name": "Strategy Game",
+    "name": "Game Strategy Game",
     "prompt": "Strategy game style {prompt} . Overhead view, detailed map, units, reminiscent of real-time strategy video games",
     "negative_prompt": "first-person view, modern, photorealistic"
   },
   {
-    "name": "Street Fighter",
+    "name": "Game Street Fighter",
     "prompt": "Street Fighter style {prompt} . Vibrant, dynamic, arcade, 2D fighting game, highly detailed, reminiscent of Street Fighter series",
     "negative_prompt": "3D, realistic, modern, photorealistic, turn-based strategy"
   },
   {
-    "name": "Legend of Zelda",
+    "name": "Game Legend of Zelda",
     "prompt": "Legend of Zelda style {prompt} . Vibrant, fantasy, detailed, epic, heroic, reminiscent of The Legend of Zelda series",
     "negative_prompt": "sci-fi, modern, realistic, horror"
   },
   {
-    "name": "Architectural",
+    "name": "Misc Architectural",
     "prompt": "Architectural style {prompt} . Clean lines, geometric shapes, minimalist, modern, architectural drawing, highly detailed",
     "negative_prompt": "curved lines, ornate, baroque, abstract, grunge"
   },
   {
-    "name": "Disco",
+    "name": "Misc Disco",
     "prompt": "Disco-themed {prompt} . Vibrant, groovy, retro 70s style, shiny disco balls, neon lights, dance floor, highly detailed",
     "negative_prompt": "minimalist, rustic, monochrome, contemporary, simplistic"
   },
   {
-    "name": "Dreamscape",
+    "name": "Misc Dreamscape",
     "prompt": "Dreamscape {prompt} . Surreal, ethereal, dreamy, mysterious, fantasy, highly detailed",
     "negative_prompt": "realistic, concrete, ordinary, mundane"
   },
   {
-    "name": "Dystopian",
+    "name": "Misc Dystopian",
     "prompt": "Dystopian style {prompt} . Bleak, post-apocalyptic, somber, dramatic, highly detailed",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, cheerful, optimistic, vibrant, colorful"
   },
   {
-    "name": "Fairy Tale",
+    "name": "Misc Fairy Tale",
     "prompt": "Fairy tale {prompt} . Magical, fantastical, enchanting, storybook style, highly detailed",
     "negative_prompt": "realistic, modern, ordinary, mundane"
   },
   {
-    "name": "Gothic",
+    "name": "Misc Gothic",
     "prompt": "Gothic style {prompt} . Dark, mysterious, haunting, dramatic, ornate, detailed",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, cheerful, optimistic"
   },
   {
-    "name": "Grunge",
+    "name": "Misc Grunge",
     "prompt": "Grunge style {prompt} . Textured, distressed, vintage, edgy, punk rock vibe, dirty, noisy",
     "negative_prompt": "smooth, clean, minimalist, sleek, modern, photorealistic"
   },
   {
-    "name": "Horror",
+    "name": "Misc Horror",
     "prompt": "Horror-themed {prompt} . Eerie, unsettling, dark, spooky, suspenseful, grim, highly detailed",
     "negative_prompt": "cheerful, bright, vibrant, light-hearted, cute"
   },
   {
-    "name": "Minimalist",
+    "name": "Misc Kawaii",
+    "prompt": "kawaii style {prompt} . cute, adorable, brightly colored, cheerful, anime influence, highly detailed",
+    "negative_prompt": "dark, scary, realistic, monochrome, abstract"
+  },
+  {
+    "name": "Misc Lovecraftian",
+    "prompt": "lovecraftian horror {prompt} . eldritch, cosmic horror, unknown, mysterious, surreal, highly detailed",
+    "negative_prompt": "light-hearted, mundane, familiar, simplistic, realistic"
+  },
+  {
+    "name": "Misc Macabre",
+    "prompt": "macabre style {prompt} . dark, gothic, grim, haunting, highly detailed",
+    "negative_prompt": "bright, cheerful, light-hearted, cartoonish, cute"
+  },
+  {
+    "name": "Misc Manga",
+    "prompt": "manga style {prompt} . vibrant, high-energy, detailed, iconic, Japanese comic style",
+    "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, Western comic style"
+  },
+  {
+    "name": "Misc Metropolis",
+    "prompt": "metropolis-themed {prompt} . urban, cityscape, skyscrapers, modern, futuristic, highly detailed",
+    "negative_prompt": "rural, natural, rustic, historical, simple"
+  },
+  {
+    "name": "Misc Minimalist",
     "prompt": "Minimalist style {prompt} . Simple, clean, uncluttered, modern, elegant",
     "negative_prompt": "ornate, complicated, highly detailed, cluttered, disordered, messy, noisy"
   },
   {
-    "name": "Monochrome",
+    "name": "Misc Monochrome",
     "prompt": "Monochrome {prompt} . Black and white, contrast, tone, texture, detailed",
     "negative_prompt": "colorful, vibrant, noisy, blurry, deformed"
   },
   {
-    "name": "Nautical",
+    "name": "Misc Nautical",
     "prompt": "Nautical-themed {prompt} . Sea, ocean, ships, maritime, beach, marine life, highly detailed",
     "negative_prompt": "landlocked, desert, mountains, urban, rustic"
   },
   {
-    "name": "Space",
+    "name": "Misc Space",
     "prompt": "Space-themed {prompt} . Cosmic, celestial, stars, galaxies, nebulas, planets, science fiction, highly detailed",
     "negative_prompt": "earthly, mundane, ground-based, realism"
   },
   {
-    "name": "Stained Glass",
+    "name": "Misc Stained Glass",
     "prompt": "Stained glass style {prompt} . Vibrant, beautiful, translucent, intricate, detailed",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic"
   },
   {
-    "name": "Techwear Fashion",
+    "name": "Misc Techwear Fashion",
     "prompt": "Techwear fashion {prompt} . Futuristic, cyberpunk, urban, tactical, sleek, dark, highly detailed",
     "negative_prompt": "vintage, rural, colorful, low contrast, realism, sketch, watercolor"
   },
   {
-    "name": "Tribal",
+    "name": "Misc Tribal",
     "prompt": "Tribal style {prompt} . Indigenous, ethnic, traditional patterns, bold, natural colors, highly detailed",
     "negative_prompt": "modern, futuristic, minimalist, pastel"
   },
   {
-    "name": "Zentangle",
+    "name": "Misc Zentangle",
     "prompt": "Zentangle {prompt} . Intricate, abstract, monochrome, patterns, meditative, highly detailed",
     "negative_prompt": "colorful, representative, simplistic, large fields of color"
   },
   {
-    "name": "Collage",
+    "name": "Papercraft Collage",
     "prompt": "Collage style {prompt} . Mixed media, layered, textural, detailed, artistic",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic"
   },
   {
-    "name": "Flat Papercut",
+    "name": "Papercraft Flat Papercut",
     "prompt": "Flat papercut style {prompt} . Silhouette, clean cuts, paper, sharp edges, minimalist, color block",
     "negative_prompt": "3D, high detail, noise, grainy, blurry, painting, drawing, photo, disfigured"
   },
   {
-    "name": "Kirigami",
+    "name": "Papercraft Kirigami",
     "prompt": "Kirigami representation of {prompt} . 3D, paper folding, paper cutting, Japanese, intricate, symmetrical, precision, clean lines",
     "negative_prompt": "painting, drawing, 2D, noisy, blurry, deformed"
   },
   {
-    "name": "Paper Mache",
+    "name": "Papercraft Paper Mache",
     "prompt": "Paper mache representation of {prompt} . 3D, sculptural, textured, handmade, vibrant, fun",
     "negative_prompt": "2D, flat, photo, sketch, digital art, deformed, noisy, blurry"
   },
   {
-    "name": "Paper Quilling",
+    "name": "Papercraft Paper Quilling",
     "prompt": "Paper quilling art of {prompt} . Intricate, delicate, curling, rolling, shaping, coiling, loops, 3D, dimensional, ornamental",
     "negative_prompt": "photo, painting, drawing, 2D, flat, deformed, noisy, blurry"
   },
   {
-    "name": "Papercut Collage",
+    "name": "Papercraft Papercut Collage",
     "prompt": "Papercut collage of {prompt} . Mixed media, textured paper, overlapping, asymmetrical, abstract, vibrant",
     "negative_prompt": "photo, 3D, realistic, drawing, painting, high detail, disfigured"
   },
   {
-    "name": "Papercut Shadow Box",
+    "name": "Papercraft Papercut Shadow Box",
     "prompt": "3D papercut shadow box of {prompt} . Layered, dimensional, depth, silhouette, shadow, papercut, handmade, high contrast",
     "negative_prompt": "painting, drawing, photo, 2D, flat, high detail, blurry, noisy, disfigured"
   },
   {
-    "name": "Stacked Papercut",
+    "name": "Papercraft Stacked Papercut",
     "prompt": "Stacked papercut art of {prompt} . 3D, layered, dimensional, depth, precision cut, stacked layers, papercut, high contrast",
     "negative_prompt": "2D, flat, noisy, blurry, painting, drawing, photo, deformed"
   },
   {
-    "name": "Thick Layered Papercut",
+    "name": "Papercraft Thick Layered Papercut",
     "prompt": "Thick layered papercut art of {prompt} . Deep 3D, volumetric, dimensional, depth, thick paper, high stack, heavy texture, tangible layers",
     "negative_prompt": "2D, flat, thin paper, low stack, smooth texture, painting, drawing, photo, deformed"
   },
   {
-    "name": "Alien",
+    "name": "Photo Alien",
     "prompt": "Alien-themed {prompt} . Extraterrestrial, cosmic, otherworldly, mysterious, sci-fi, highly detailed",
     "negative_prompt": "earthly, mundane, common, realistic, simple"
   },
   {
-    "name": "Film Noir",
+    "name": "Photo Film Noir",
     "prompt": "Film noir style {prompt} . Monochrome, high contrast, dramatic shadows, 1940s style, mysterious, cinematic",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, realism, photorealistic, vibrant, colorful"
   },
   {
-    "name": "HDR",
+    "name": "Photo Glamour",
+    "prompt": "glamorous photo {prompt} . high fashion, luxurious, extravagant, stylish, sensual, opulent, elegance, stunning beauty, professional, high contrast, detailed",
+    "negative_prompt": "ugly, deformed, noisy, blurry, distorted, grainy, sketch, low contrast, dull, plain, modest"
+  },
+  {
+    "name": "Photo HDR",
     "prompt": "HDR photo of {prompt} . High dynamic range, vivid, rich details, clear shadows and highlights, realistic, intense, enhanced contrast, highly detailed",
     "negative_prompt": "flat, low contrast, oversaturated, underexposed, overexposed, blurred, noisy"
   },
   {
-    "name": "Long Exposure",
+    "name": "Photo Iphone Photographic",
+    "prompt": "iphone photo {prompt} . large depth of field, deep depth of field, highly detailed",
+    "negative_prompt": "drawing, painting, crayon, sketch, graphite, impressionist, noisy, blurry, soft, deformed, ugly, shallow depth of field, bokeh"
+  },
+  {
+    "name": "Photo Long Exposure",
     "prompt": "Long exposure photo of {prompt} . Blurred motion, streaks of light, surreal, dreamy, ghosting effect, highly detailed",
     "negative_prompt": "static, noisy, deformed, shaky, abrupt, flat, low contrast"
   },
   {
-    "name": "Neon Noir",
+    "name": "Photo Neon Noir",
     "prompt": "Neon noir {prompt} . Cyberpunk, dark, rainy streets, neon signs, high contrast, low light, vibrant, highly detailed",
     "negative_prompt": "bright, sunny, daytime, low contrast, black and white, sketch, watercolor"
   },
   {
-    "name": "Silhouette",
+    "name": "Photo Silhouette",
     "prompt": "Silhouette style {prompt} . High contrast, minimalistic, black and white, stark, dramatic",
     "negative_prompt": "ugly, deformed, noisy, blurry, low contrast, color, realism, photorealistic"
   },
   {
-    "name": "Tilt-Shift",
+    "name": "Photo Tilt-Shift",
     "prompt": "Tilt-shift photo of {prompt} . Selective focus, miniature effect, blurred background, highly detailed, vibrant, perspective control",
     "negative_prompt": "blurry, noisy, deformed, flat, low contrast, unrealistic, oversaturated, underexposed"
   }


### PR DESCRIPTION
1. Grouped existing styles with prefixes. The .json file is already organized by style category, but the code is designed to alphabetically sort the styles into the web UI selector. Using prefixes will retain the category groupings.
2. Added all styles from https://stable-diffusion-art.com/sdxl-styles/ The final list is inconveniently long in the web UI, but there are some interesting styles that were missing, like all the Futuristic ones. Perhaps a future version could enhance the UI with separate expandable groups to make it more convenient on the screen. Meanwhile, it's always possible to just collapse the whole list when you're not using it.
